### PR TITLE
Improve compatibility to work with Node >=10.12.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -123,7 +123,7 @@ if(typeof arg.e === 'string') {
 	filename = filename.replace( /\//g, '\\')
 
 	var exists = grf.getFile(filename, function(data){
-		var buf = new Buffer( new Uint8Array(data))
+		var buf = Buffer.from(new Uint8Array(data))
 		process.stdout.write(buf)
 	})
 

--- a/lib/Loaders/GameFile.js
+++ b/lib/Loaders/GameFile.js
@@ -105,9 +105,9 @@ GRF.prototype.load   = function Load( file )
 	reader.load = function( start, len ) {
 		// node.js
 		if (fs && file.fd) {
-			var buffer = new Buffer(len);
+			var buffer = Buffer.alloc(len);
 			fs.readSync(file.fd, buffer, 0, len, start);
-			return (new Uint8Array(buffer)).buffer;
+			return buffer.buffer;
 		}
 
 		return reader.readAsArrayBuffer(

--- a/lib/extractor.js
+++ b/lib/extractor.js
@@ -7,8 +7,8 @@ var Cluster = require('cluster')
 var Os = require('os')
 var Fs = require('fs')
 var Util = require('util')
-var Mkdirp = require('mkdirp')
 var Zlib = require('zlib')
+var fs = require('fs')
 
 // Constructor
 var Extractor = function Constructor(grf, options) {
@@ -119,7 +119,7 @@ function extractStart() {
 
 			var i = next++
 			var entry = entries[i]
-			var buffer = new Buffer(entry.length_aligned);
+			var buffer = Buffer.alloc(entry.length_aligned);
 			var file = entry.filename.replace( /\\/g, '/') // Replace windows back slash \ to unix forward slash
 			var fullpath = extract_folder + file
 
@@ -168,7 +168,7 @@ Extractor.prototype.makeDir = function mkDir(path, callback) {
 	if(typeof this.mkdirPaths[path] === 'undefined') {
 		var self = this
 
-		Mkdirp(path, function (err) {
+		fs.mkdir(path, { recursive: true }, function (err) {
 			if(err) {
 				console.error("Unexpected error while trying to create dir", path)
 				console.error(err)
@@ -193,12 +193,12 @@ Extractor.prototype.writeEntry = function writeEntry(entry, path, buffer, callba
 	if (entry.type & GRF.FILELIST_TYPE_ENCRYPT_MIXED) {
 		var data = new Uint8Array(buffer)
 		GameFileDecrypt.decodeFull( data, entry.length_aligned, entry.pack_size)
-		buffer = new Buffer(data)
+		buffer = Buffer.from(data)
 	}
 	else if (entry.type & GRF.FILELIST_TYPE_ENCRYPT_HEADER) {
 		var data = new Uint8Array(buffer)
 		GameFileDecrypt.decodeHeader( data, entry.length_aligned )
-		buffer = new Buffer(data)
+		buffer = Buffer.from(data)
 	}
 
 	var self = this

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,57 @@
+{
+  "name": "grf-extractor",
+  "version": "1.0.34",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "grf-extractor",
+      "version": "1.0.34",
+      "license": "MIT",
+      "dependencies": {
+        "optimist": "^0.6.1",
+        "progress": "^2.0.3"
+      },
+      "bin": {
+        "grf-extractor": "index.js"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+      "integrity": "sha512-iotkTvxc+TwOm5Ieim8VnSNvCDjCK9S8G3scJ50ZthspSxa7jx50jkhYduuAtAjvfDUwSgOwf8+If99AlOEhyw==",
+      "license": "MIT"
+    },
+    "node_modules/optimist": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "integrity": "sha512-snN4O4TkigujZphWLN0E//nQmm7790RYaE53DdL7ZYwee2D8DDo9/EyYiKUfN3rneWUjhJnueija3G9I2i0h3g==",
+      "license": "MIT/X11",
+      "dependencies": {
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
+      }
+    },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/wordwrap": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+      "integrity": "sha512-1tMA907+V4QmxV7dbRvb4/8MaRALK6q9Abid3ndMYnbyo8piisCmeONVqVSXqQA3KaP4SLt5b7ud6E2sqP8TFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A command line GRF extractor, used to manage Ragnarok's .grf files.",
   "main": "index.js",
   "bin": {
-	  "grf-extractor": "./index.js"
+    "grf-extractor": "./index.js"
   },
   "scripts": {
     "test": "npm test"
@@ -26,11 +26,10 @@
   },
   "homepage": "https://github.com/herenow/grf-extractor",
   "dependencies": {
-    "mkdirp": "^0.5.0",
     "optimist": "^0.6.1",
-    "progress": "^1.1.8"
+    "progress": "^2.0.3"
   },
-  "devDependencies": {
-    "webkit-devtools-agent": "^0.3.1"
+  "engines": {
+    "node": ">=10.12.0"
   }
 }


### PR DESCRIPTION
When I tried to use this tool from source I got several errors when trying to install dependencies for the project. The main issue was the compatibility between the code and the newer version of Node.js (v22.14.0).

Specifically, the webkit-devtools-agent dependency was failing to build because it's using outdated V8 (Node.js's JavaScript engine) APIs that are no longer available in newer Node.js versions. 

Some key issues include:
- Using deprecated V8 API calls like String::NewSymbol
- Trying to access protected/private members that have changed in newer V8 versions
- Missing required parameters in V8 function calls
- Using old-style V8 argument handling that's no longer supported

These are common issues with native Node.js modules (those using node-gyp to compile C++ code) that haven't been updated to support newer Node.js versions.

This pull request includes several updates to modernize the codebase by replacing deprecated methods and updating dependencies. The most important changes include replacing the `Buffer` constructor with modern methods, updating the `mkdirp` dependency, and modifying the `package.json` file to specify the required Node.js version.

### Buffer Method Updates:
* [`index.js`](diffhunk://#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346L126-R126): Replaced `new Buffer` with `Buffer.from` for creating buffers from `Uint8Array` data.
* [`lib/Loaders/GameFile.js`](diffhunk://#diff-abe54b2ed69ad4f6b74541968e7902632c05cd5a039aebebe84d115316dac966L108-R110): Replaced `new Buffer` with `Buffer.alloc` for allocating buffers of a specified length.
* [`lib/extractor.js`](diffhunk://#diff-789c1ba9c77fca540102e843cc32301f248fe0c95e63e932090ee761554580ebL122-R122): Replaced `new Buffer` with `Buffer.alloc` for allocating buffers of a specified length.
* [`lib/extractor.js`](diffhunk://#diff-789c1ba9c77fca540102e843cc32301f248fe0c95e63e932090ee761554580ebL196-R201): Replaced `new Buffer` with `Buffer.from` for creating buffers from `Uint8Array` data.

### Dependency Updates:
* [`lib/extractor.js`](diffhunk://#diff-789c1ba9c77fca540102e843cc32301f248fe0c95e63e932090ee761554580ebL171-R171): Replaced `mkdirp` with `fs.mkdir` using the `recursive` option for creating directories.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L29-R33): Removed `mkdirp` and updated the `progress` dependency to a newer version. Also specified the required Node.js version as `>=10.12.0`.

After these changes, I tested the tool and got the following output:
```
Extraction has started on 920 files.
Progress [920/920] [============================================================] 100% 0.1s - 0.0s
Finished extracting GRF.
```