### PR TITLE
feat(cps): add CPS decryption, large GRF support, and error improvements

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,6 +42,10 @@ argv.options('v', {
 argv.options('version', {
 	describe: 'Print package version.',
 })
+argv.options('k', {
+	alias: 'key',
+	describe: 'Path to a cps.dll for decrypting encrypted GRF files.',
+})
 argv.options('h', {
 	alias: 'help',
 	describe: 'Print help and usage information',
@@ -59,7 +63,7 @@ if(arg.version) {
 
 // Print help
 if(!arg.g || arg.h) {
-	console.error("Usage: grf-extractor -g data.grf -o output_dir")
+	console.error("Usage: grf-extractor -g data.grf -o output_dir [-k cps.dll]")
 	argv.showHelp()
 	return
 }
@@ -135,10 +139,27 @@ if(typeof arg.e === 'string') {
 	return
 }
 
+// Load CPS decryption key if provided
+var Cluster = require('cluster')
+var cpsSbox = null
+if(typeof arg.k === 'string') {
+	var Cps = require('./lib/cps.js')
+	try {
+		cpsSbox = Cps.loadKey(arg.k)
+		if(Cluster.isMaster) {
+			console.log("Loaded CPS decryption key from %s", arg.k)
+		}
+	} catch(err) {
+		console.error("Failed to load CPS key:", err.message)
+		return
+	}
+}
+
 // Default action, extract the entire grf
 var extraction = grf.extract({
 	output: (typeof arg.o !== 'string' ? '' : arg.o),
 	concurrency: arg.c,
+	cpsSbox: cpsSbox,
 })
 
 extraction.on('start', function() {

--- a/lib/Loaders/GameFile.js
+++ b/lib/Loaders/GameFile.js
@@ -199,11 +199,11 @@ GRF.prototype.load   = function Load( file )
 
 		entries[i] = {
 			filename:       str,
-			pack_size:      out[pos++] | out[pos++] << 8 | out[pos++] << 16 | out[pos++] << 24,
-			length_aligned: out[pos++] | out[pos++] << 8 | out[pos++] << 16 | out[pos++] << 24,
-			real_size:      out[pos++] | out[pos++] << 8 | out[pos++] << 16 | out[pos++] << 24,
+			pack_size:      (out[pos++] | out[pos++] << 8 | out[pos++] << 16 | out[pos++] << 24) >>> 0,
+			length_aligned: (out[pos++] | out[pos++] << 8 | out[pos++] << 16 | out[pos++] << 24) >>> 0,
+			real_size:      (out[pos++] | out[pos++] << 8 | out[pos++] << 16 | out[pos++] << 24) >>> 0,
 			type:           out[pos++],
-			offset:         out[pos++] | out[pos++] << 8 | out[pos++] << 16 | out[pos++] << 24
+			offset:         (out[pos++] | out[pos++] << 8 | out[pos++] << 16 | out[pos++] << 24) >>> 0
 		};
 	}
 

--- a/lib/cps.js
+++ b/lib/cps.js
@@ -1,0 +1,65 @@
+// CPS (cps.dll / Fury.dll) decryption support
+// Extracts the RC4 S-box from a cps.dll and provides decryption for GRF entries
+
+var fs = require('fs')
+
+// Load encryption key from a cps.dll file and build the RC4 S-box
+function loadKey(dllPath) {
+	var dll = fs.readFileSync(dllPath)
+
+	// Search for UTF-16LE L"NUMBER" marker
+	var pattern = [0x4E, 0x00, 0x55, 0x00, 0x4D, 0x00, 0x42, 0x00, 0x45, 0x00, 0x52, 0x00]
+	var offset = -1
+
+	for (var i = 0; i < dll.length - pattern.length; i++) {
+		var match = true
+		for (var j = 0; j < pattern.length; j++) {
+			if (dll[i + j] !== pattern[j]) { match = false; break }
+		}
+		if (match) { offset = i; break }
+	}
+
+	if (offset === -1) {
+		throw new Error('CPS: Could not find encryption key in ' + dllPath)
+	}
+
+	// Key is after L"NUMBER\0" (14 bytes) + 4 byte header
+	var keyStart = offset + 14 + 4
+	var key = dll.slice(keyStart, keyStart + 260)
+
+	if (key.length < 260) {
+		throw new Error('CPS: Not enough key data in ' + dllPath)
+	}
+
+	// Build S-box using the DLL's key scheduling algorithm
+	var a = (key[3] << 24) | (key[2] << 16) | (key[1] << 8) | key[0]
+	var sbox = new Uint8Array(256)
+	for (var i = 0; i < 256; i++) {
+		sbox[i] = ((a & 0xFF) ^ key[i + 4]) & 0xFF
+		a = Math.imul(a, 0x2F)
+	}
+
+	return sbox
+}
+
+// RC4 decrypt a buffer in-place using the S-box
+// initialI is typically the entry's real_size (decompressed size)
+function decrypt(buffer, sbox, initialI) {
+	var S = new Uint8Array(sbox) // working copy
+	var i = initialI & 0xFF
+	var j = 0
+
+	for (var k = 0; k < buffer.length; k++) {
+		i = (i + 1) & 0xFF
+		j = (j + S[i]) & 0xFF
+		var tmp = S[i]; S[i] = S[j]; S[j] = tmp
+		buffer[k] ^= S[(S[i] + S[j]) & 0xFF]
+	}
+
+	return buffer
+}
+
+module.exports = {
+	loadKey: loadKey,
+	decrypt: decrypt
+}

--- a/lib/cps.js
+++ b/lib/cps.js
@@ -3,32 +3,39 @@
 
 var fs = require('fs')
 
-// Load encryption key from a cps.dll file and build the RC4 S-box
-function loadKey(dllPath) {
-	var dll = fs.readFileSync(dllPath)
+// Load encryption key from a CPS DLL or a raw S-box hex file
+function loadKey(path) {
+	var data = fs.readFileSync(path)
 
-	// Search for UTF-16LE L"NUMBER" marker
+	// If the file is small and looks like a hex dump (text file), parse as raw S-box
+	var text = data.toString('utf8').trim()
+	var hexMatch = text.match(/^(?:SBOX:)?([0-9a-fA-F]{512})$/)
+	if (hexMatch) {
+		return new Uint8Array(Buffer.from(hexMatch[1], 'hex'))
+	}
+
+	// Otherwise treat as a DLL: search for UTF-16LE L"NUMBER" marker
 	var pattern = [0x4E, 0x00, 0x55, 0x00, 0x4D, 0x00, 0x42, 0x00, 0x45, 0x00, 0x52, 0x00]
 	var offset = -1
 
-	for (var i = 0; i < dll.length - pattern.length; i++) {
+	for (var i = 0; i < data.length - pattern.length; i++) {
 		var match = true
 		for (var j = 0; j < pattern.length; j++) {
-			if (dll[i + j] !== pattern[j]) { match = false; break }
+			if (data[i + j] !== pattern[j]) { match = false; break }
 		}
 		if (match) { offset = i; break }
 	}
 
 	if (offset === -1) {
-		throw new Error('CPS: Could not find encryption key in ' + dllPath)
+		throw new Error('CPS: Could not find encryption key in ' + path)
 	}
 
 	// Key is after L"NUMBER\0" (14 bytes) + 4 byte header
 	var keyStart = offset + 14 + 4
-	var key = dll.slice(keyStart, keyStart + 260)
+	var key = data.slice(keyStart, keyStart + 260)
 
 	if (key.length < 260) {
-		throw new Error('CPS: Not enough key data in ' + dllPath)
+		throw new Error('CPS: Not enough key data in ' + path)
 	}
 
 	// Build S-box using the DLL's key scheduling algorithm

--- a/lib/extractor.js
+++ b/lib/extractor.js
@@ -129,8 +129,7 @@ function extractStart() {
 				// Read entry from .grf file
 				Fs.read(grf.file.fd, buffer, 0, entry.length_aligned, entry.offset + GRF.struct_header.size, function(err, bytesRead, buffer){
 					if(err) {
-						console.error("Unexpected error while reading file %s from grf", fullpath)
-						console.error(err)
+						console.error("Error reading %s: %s", file, err.message)
 						finish()
 						return
 					}
@@ -172,8 +171,7 @@ Extractor.prototype.makeDir = function mkDir(path, callback) {
 
 		fs.mkdir(path, { recursive: true }, function (err) {
 			if(err) {
-				console.error("Unexpected error while trying to create dir", path)
-				console.error(err)
+				console.error("Error creating directory %s: %s", path, err.message)
 			}
 
 			// Add to created paths hashtable
@@ -229,16 +227,14 @@ Extractor.prototype.writeEntry = function writeEntry(entry, path, buffer, callba
 					writeInflated(buf2)
 					return
 				}
-				console.error("Unexpected error while inflating", path)
-				console.error(err2)
+				console.error("Error decompressing %s: %s", path, err.message2)
 				callback()
 			})
 		})
 	} else {
 		Zlib.inflate(buffer, function(err, buf) {
 			if(err) {
-				console.error("Unexpected error while inflating", path)
-				console.error(err)
+				console.error("Error decompressing %s: %s", path, err.message)
 				callback()
 				return
 			}
@@ -251,8 +247,7 @@ Extractor.prototype.writeEntry = function writeEntry(entry, path, buffer, callba
 Extractor.prototype.writeFile = function writeFile(path, buffer, callback) {
 	Fs.writeFile(path, buffer, function (err) {
 		if (err) {
-			console.error("Unexpected error while writing %s to file", path)
-			console.error(err)
+			console.error("Error writing %s: %s", path, err.message)
 		}
 
 		callback()

--- a/lib/extractor.js
+++ b/lib/extractor.js
@@ -8,6 +8,7 @@ var Os = require('os')
 var Fs = require('fs')
 var Util = require('util')
 var Zlib = require('zlib')
+var Cps = require('./cps.js')
 var fs = require('fs')
 
 // Constructor
@@ -16,6 +17,7 @@ var Extractor = function Constructor(grf, options) {
 	this.grf = grf
 	this.concurrency = options.concurrency || 100
 	this.output_dir = options.output || ''
+	this.cpsSbox = options.cpsSbox || null
 	this.mkdirPaths = [] // List of paths already created
 
 	// Start at next tick, give time for event listener to bind
@@ -203,22 +205,46 @@ Extractor.prototype.writeEntry = function writeEntry(entry, path, buffer, callba
 
 	var self = this
 
-	// Decompress the buffer
-	Zlib.inflate(buffer, function(err, buf) {
-		if(err) {
-			console.error("Unexpected error while inflating", path)
-			console.error(err)
-			callback()
-			return
-		}
-
-		// Extract folder from file path
-		var folder = path.substring(0, path.lastIndexOf("/")) 
-
+	function writeInflated(buf) {
+		var folder = path.substring(0, path.lastIndexOf("/"))
 		self.makeDir(folder, function() {
-			self.writeFile(path, buffer, callback)
+			self.writeFile(path, buf, callback)
 		})
-	})
+	}
+
+	if (self.cpsSbox) {
+		// CPS encrypted GRF: RC4 decrypt a copy, then inflate
+		var decrypted = Buffer.from(buffer)
+		Cps.decrypt(decrypted, self.cpsSbox, entry.real_size)
+
+		Zlib.inflate(decrypted, function(err, buf) {
+			if(!err) {
+				writeInflated(buf)
+				return
+			}
+
+			// Fallback: try without CPS decryption (some files may be unencrypted)
+			Zlib.inflate(buffer, function(err2, buf2) {
+				if(!err2) {
+					writeInflated(buf2)
+					return
+				}
+				console.error("Unexpected error while inflating", path)
+				console.error(err2)
+				callback()
+			})
+		})
+	} else {
+		Zlib.inflate(buffer, function(err, buf) {
+			if(err) {
+				console.error("Unexpected error while inflating", path)
+				console.error(err)
+				callback()
+				return
+			}
+			writeInflated(buf)
+		})
+	}
 }
 
 // Write buffer to file


### PR DESCRIPTION
Add support for extracting CPS/Fury-encrypted GRF files, fix extraction of large GRFs, and clean up error output.

- Add `-k`/`--key` option to specify a CPS decryption key source
- Support both CPS DLLs and raw S-box hex files
- RC4 stream cipher decryption with fallback to plain inflate for unencrypted entries
- Fix signed integer overflow on entry offsets > 2GB in large GRF files
- Fix bug where compressed data was written to disk instead of decompressed data
- Simplify error messages to single-line output without stack traces

### Usage

Standard CPS DLL:
```sh
grf-extractor -g data.grf -k cps.dll -o output_dir
```

Raw S-box file:
```sh
grf-extractor -g data.grf -k sbox_dump.txt -o output_dir
```